### PR TITLE
Correction for point.reflected_across()

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svg.elements
-version = 0.3.1
+version = 0.3.2
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/svg/elements/svg_elements.py
+++ b/svg/elements/svg_elements.py
@@ -1105,7 +1105,8 @@ class Point:
         return Point.polar(self, angle, distance)
 
     def reflected_across(self, p):
-        m = p + p
+        m = Point(p)
+        m += p
         m -= self
         return m
 


### PR DESCRIPTION
Point.reflected_across had an order of operations that caused the input to be added before it was forcibly wrapped in a Point class.  This caused invalid behavior when the operand was not strictly a point to begin with.